### PR TITLE
added underscore support for parsing hex, oct and dec

### DIFF
--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -13,6 +13,7 @@ func useCLI(target string) error {
 
 	switch {
 	case strings.HasPrefix(target, "0x"):
+		target = strings.Replace(target, "_", "", -1)
 		tmp, err := strconv.ParseInt(target[2:], 16, 64)
 		if err != nil {
 			return fmt.Errorf("parse error: invalid hexdecimal value")
@@ -26,12 +27,14 @@ func useCLI(target string) error {
 		}
 		decimal = tmp
 	case strings.HasPrefix(target, "0"):
+		target = strings.Replace(target, "_", "", -1)
 		tmp, err := strconv.ParseInt(target[1:], 8, 64)
 		if err != nil {
 			return fmt.Errorf("parse error: invalid octal value")
 		}
 		decimal = tmp
 	default:
+		target = strings.Replace(target, "_", "", -1)
 		tmp, err := strconv.ParseInt(target, 10, 64)
 		if err != nil {
 			return fmt.Errorf("parse error: invalid decimal value")


### PR DESCRIPTION
At the time to parse numbers, only binary had support for underscore, so behaviour like ```bitwise 0b0100_1000``` works, but ```bitwise 10_000_000``` doesn't. This commit aims to add support for underscore in all formats and not just binary